### PR TITLE
feat: use CLAUDE.md imports syntax for rule references

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,12 +7,7 @@
         "cursor-rules-to-claude": "./dist/index.js"
     },
     "type": "module",
-    "files": [
-        "dist",
-        "README.md",
-        "LICENSE",
-        "package.json"
-    ],
+    "files": ["dist", "README.md", "LICENSE", "package.json"],
     "scripts": {
         "dev": "bun run src/index.ts",
         "build": "bun build src/index.ts --outdir=dist --target=node",
@@ -24,14 +19,7 @@
         "check": "biome check .",
         "check:fix": "biome check --fix ."
     },
-    "keywords": [
-        "cursor",
-        "claude",
-        "cli",
-        "rules",
-        "ai",
-        "github-action"
-    ],
+    "keywords": ["cursor", "claude", "cli", "rules", "ai", "github-action"],
     "author": "",
     "license": "MIT",
     "repository": {
@@ -52,7 +40,5 @@
     "peerDependencies": {
         "typescript": "^5"
     },
-    "trustedDependencies": [
-        "@biomejs/biome"
-    ]
+    "trustedDependencies": ["@biomejs/biome"]
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -121,7 +121,7 @@ ${DIVIDERS.GENERATED_BY}
         rulesContent += `>${rule.description}\n`;
       }
 
-      rulesContent += `This rule can be found [here](${rulesDir}/${rule.filename}.md)\n\n`;
+      rulesContent += `This rule can be found @${rulesDir}/${rule.filename}.md\n\n`;
       rulesContent += `${rule.content}\n\n`;
     }
   }
@@ -145,7 +145,7 @@ ${DIVIDERS.GENERATED_BY}
         rulesContent += `This refers to: ${rule.globs}\n\n`;
       }
 
-      rulesContent += `Read the full rule [here](${rulesDir}/${rule.filename}.md)\n\n`;
+      rulesContent += `Read the full rule @${rulesDir}/${rule.filename}.md\n\n`;
     }
   }
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -73,7 +73,7 @@ describe('cursor-rules-to-claude CLI', () => {
     const content = readFileSync(outputFile, 'utf-8');
     expect(content).toContain('# Agent Requested');
     expect(content).toContain('>Conditional test rule');
-    expect(content).toContain('Read the full rule [here]');
+    expect(content).toContain('Read the full rule @');
     expect(content).not.toContain('Conditional point 1');
   });
 
@@ -240,6 +240,6 @@ alwaysApply: false
     const content = readFileSync(outputFile, 'utf-8');
     expect(content).toContain('# No Globs');
     expect(content).toContain('>"Test rule"');
-    expect(content).toContain('Read the full rule [here]');
+    expect(content).toContain('Read the full rule @');
   });
 });


### PR DESCRIPTION
## Summary
- Replace markdown link syntax with @ syntax for file references in generated CLAUDE.md
- This enables the CLAUDE.md imports feature as documented in https://docs.anthropic.com/en/docs/claude-code/memory#claude-md-imports

## Changes
- Changed markdown links to @ syntax in src/index.ts
- Affects both full rule inclusions and reference-only rule links

## Benefits
- Claude Code will automatically import referenced rules when reading the generated CLAUDE.md file
- Improves the integration with Claude Code memory management features
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Updated CLAUDE.md rule references to use the @ imports syntax instead of markdown links, so Claude Code can automatically import referenced rules.

- **Integration**
 - Switched all rule file links to @ syntax for both full inclusions and reference-only links.

<!-- End of auto-generated description by cubic. -->

